### PR TITLE
Fix node compatibility

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
     filename: '[name].js',
     libraryTarget: 'umd',
     library: 'CrunchyrollLib',
-    umdNamedDefine: true
+    umdNamedDefine: true,
+    globalObject: 'this'
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js']


### PR DESCRIPTION
Hey there!

This implementation of the Crunchyroll API is great! I noticed, however, that the build would not work in Node, since webpack@4 seems to have a bug which does not allow it to be used on the node side ( https://github.com/webpack/webpack/issues/6522 ). This small commit adds the change which appears to allow it to work in Node. 